### PR TITLE
added `showUrl` `show` arg

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ Instance method to parse arguments in window. You would only need to call from y
 Instance method that shows the url. When the url is finished loading, the callback is returned. If the optional `argsForRenderer` is set
 then `__args__` will be a global object for the page in the renderer process. This is a convenient way to pass
 arguments from the main process to the renderer process.
+`argsForRenderer` could also contains boolean `show`. If set to `false`, the window is not showed on loading. Defaults to `true`. This argument is removed from `argsForRenderer` object before being passed to renderer process.
 
 
 #### unref()

--- a/lib/main.js
+++ b/lib/main.js
@@ -52,8 +52,20 @@ function createWindow (options) {
       args = null
     }
 
+    var showWindow = true
+    if (args) {
+      if (args.show) {
+        showWindow = !!args.show
+      }
+
+      // remove show arg since it's not passed to renderer
+      delete args.show
+    }
+
     window._loadUrlWithArgs(httpOrFileUrl, args, function () {
-      window.show()
+      if (showWindow) {
+        window.show()
+      }
       callback && callback.apply(this, arguments)
     })
   }


### PR DESCRIPTION
I needed to load a page url, but keep the window hidden, to show after I do other stuff in renderer process. 

I added a `show` arg to `showUrl` function that is checked before showing the window, and then removed from the arg object, to avoid pass it to renderer process. It default to true, so it doesn't break compatibility.

It is a little weird because the function param is called `argsForRenderer`, while this new arg is not really for renderer, but I'm unsure how to change the api... also, I'm unsure how to test this new arg.
If you suggest some improvement, I will be more than happy to improve the PR 

