### PR TITLE
Change win.loadUrl to win.loadURL

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -37,7 +37,10 @@ function _loadUrlWithArgs (httpOrFileUrl, args, callback) {
   })
 
   var url = wargs.urlWithArgs(httpOrFileUrl, args)
-  win.loadURL(url)
+
+  // support versions of electron < 0.35.0 before loadUrl was deprecated
+  var loadUrl = win.loadURL ? win.loadURL.bind(win) : win.loadUrl.bind(win)
+  loadUrl(url)
 }
 
 function createWindow (options) {

--- a/lib/main.js
+++ b/lib/main.js
@@ -37,7 +37,7 @@ function _loadUrlWithArgs (httpOrFileUrl, args, callback) {
   })
 
   var url = wargs.urlWithArgs(httpOrFileUrl, args)
-  win.loadUrl(url)
+  win.loadURL(url)
 }
 
 function createWindow (options) {


### PR DESCRIPTION
This fixes #4, where a deprecation warning occurs when calling BrowserWindow.loadUrl().

I understand if you want to hold off on this because it could break for developers running Electron < v0.35.0. I'm not sure how you want to handle this.