### PR TITLE
Remove 0.37 deprecation warnings

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -2,6 +2,7 @@ var assign = require('object-assign')
 var path = require('path')
 var BrowserWindow = require('browser-window')
 var wargs = require('./args')
+var v = process.versions.electron.split('.').map(Number)
 
 // retain global references, if not, window will be closed automatically when
 // garbage collected
@@ -9,9 +10,16 @@ var _windows = {}
 
 function _createWindow (options) {
   var opts = assign({
-    show: false,
-    preload: path.join(__dirname, 'renderer-preload')
+    show: false
   }, options)
+
+  if (v[0] === 0 && v[1] < 37) {
+    opts.preload = path.join(__dirname, 'renderer-preload')
+  } else {
+    opts.webPreferences = assign({
+      preload: path.join(__dirname, 'renderer-preload')
+    }, options.webPreferences)
+  }
 
   var window = new BrowserWindow(opts)
   _windows[window.id] = window

--- a/lib/main.js
+++ b/lib/main.js
@@ -2,7 +2,7 @@ var assign = require('object-assign')
 var path = require('path')
 var BrowserWindow = require('browser-window')
 var wargs = require('./args')
-var v = process.versions.electron.split('.').map(Number)
+var v = (process.versions.electron || '').split('.').map(Number)
 
 // retain global references, if not, window will be closed automatically when
 // garbage collected


### PR DESCRIPTION
This removes deprecation warnings in 0.37

Since the tests run outside of Electron I'm just defaulting to an empty version string to make sure the tests don't fail.