### PR TITLE
Fix preload scripts in electron-window

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -13,9 +13,8 @@ function _createWindow (options) {
     show: false
   }, options)
 
-  if (v[0] === 0 && v[1] < 37) {
-    opts.preload = path.join(__dirname, 'renderer-preload')
-  } else {
+  opts.preload = path.join(__dirname, 'renderer-preload')
+  if (v[0] === 0 && v[1] >= 37) {
     opts.webPreferences = assign({
       preload: path.join(__dirname, 'renderer-preload')
     }, options.webPreferences)


### PR DESCRIPTION
This bug breaks running renderer tests in electron-mocha on 0.37.5. I'm not sure why the docs say that preload moved to webPreferences.