### PR TITLE
removed options.preload deprecation errors.

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -13,11 +13,12 @@ function _createWindow (options) {
     show: false
   }, options)
 
-  opts.preload = path.join(__dirname, 'renderer-preload')
   if (v[0] === 0 && v[1] >= 37) {
     opts.webPreferences = assign({
       preload: path.join(__dirname, 'renderer-preload')
     }, options.webPreferences)
+  } else {
+    opts.preload = path.join(__dirname, 'renderer-preload')
   }
 
   var window = new BrowserWindow(opts)


### PR DESCRIPTION
While testing --renderer processes with electron-mocha, I kept receiving the warning/error:

> (electron) options.preload is deprecated. Use options.webPreferences.preload instead.

I've gone and fixed this issue by leveraging your node version 37 check; since that was apparently when options.preload became deprecated per #11 .