### PR TITLE
Use opts.preload when Electron version is less than 0.37.3

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -13,8 +13,10 @@ function _createWindow (options) {
     show: false
   }, options)
 
-  opts.preload = path.join(__dirname, 'renderer-preload')
-  if (v[0] === 0 && v[1] >= 37) {
+  // options.preload was deprecated for options.webPreferences.preload in 0.37.3
+  if (v[0] === 0 && (v[1] <= 36 || (v[1] === 37 && v[2] < 3))) {
+    opts.preload = path.join(__dirname, 'renderer-preload')
+  } else {
     opts.webPreferences = assign({
       preload: path.join(__dirname, 'renderer-preload')
     }, options.webPreferences)


### PR DESCRIPTION
This PR resolves #11 and suppresses Electron's deprecation warning for the `preload` property.
- Use `opts.preload` when Electron's version is < 0.37.3
- Use `opts.webPreferences.preload` when Electron's version is >= 0.37.3