### PR TITLE
Support Electron 1.0

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -1,6 +1,6 @@
 var assign = require('object-assign')
 var path = require('path')
-var BrowserWindow = require('browser-window')
+var BrowserWindow = require('electron').BrowserWindow
 var wargs = require('./args')
 var v = (process.versions.electron || '').split('.').map(Number)
 


### PR DESCRIPTION
Requiring `browser-window` fails on 1.0.

I'm assuming the API will change less frequently from here on out, so I'll remove all the version checks in a separate PR if you agree.