### PR TITLE
Use Electron 1.0 API consistently

### DIFF
--- a/lib/__tests__/main.test.js
+++ b/lib/__tests__/main.test.js
@@ -10,9 +10,11 @@ describe('main', function () {
     it('should should create the window with options and set global window references', function () {
       function BrowserWindow (options) { this.id = 5; this._captureOptions = options }
       var stubs = {
-        'browser-window': BrowserWindow
+        electron: {
+          BrowserWindow: BrowserWindow
+        }
       }
-      stubs['browser-window']['@noCallThru'] = true
+      stubs.electron['@noCallThru'] = true
       var main = proxyquire('../main', stubs)
 
       var win = main._createWindow({frame: 'something'})
@@ -22,20 +24,20 @@ describe('main', function () {
     })
   })
 
-  describe('_loadUrlWithArgs()', function () {
+  describe('_loadURLWithArgs()', function () {
     it('should load url and callback when finished', function (done) {
-      var stubs = {'browser-window': {}}
-      stubs['browser-window']['@noCallThru'] = true
+      var stubs = { electron: { BrowserWindow: {} } }
+      stubs.electron['@noCallThru'] = true
       var main = proxyquire('../main', stubs)
 
       var win = {
         webContents: new EventEmitter(),
-        loadUrl: function () {
+        loadURL: function () {
           this.webContents.emit('did-finish-load')
         }
       }
 
-      var fn = main._loadUrlWithArgs.bind(win)
+      var fn = main._loadURLWithArgs.bind(win)
       fn('http://somesite.com', {}, function () {
         done()
       })
@@ -44,8 +46,8 @@ describe('main', function () {
 
   describe('_unref()', function () {
     it('should delete global reference', function () {
-      var stubs = {'browser-window': {}}
-      stubs['browser-window']['@noCallThru'] = true
+      var stubs = { electron: { BrowserWindow: {} } }
+      stubs.electron['@noCallThru'] = true
       var main = proxyquire('../main', stubs)
 
       var win = {id: 3}

--- a/lib/main.js
+++ b/lib/main.js
@@ -1,8 +1,7 @@
 var assign = require('object-assign')
 var path = require('path')
-var BrowserWindow = require('browser-window')
+var BrowserWindow = require('electron').BrowserWindow
 var wargs = require('./args')
-var v = (process.versions.electron || '').split('.').map(Number)
 
 // retain global references, if not, window will be closed automatically when
 // garbage collected
@@ -13,14 +12,9 @@ function _createWindow (options) {
     show: false
   }, options)
 
-  // options.preload was deprecated for options.webPreferences.preload in 0.37.3
-  if (v[0] === 0 && (v[1] <= 36 || (v[1] === 37 && v[2] < 3))) {
-    opts.preload = path.join(__dirname, 'renderer-preload')
-  } else {
-    opts.webPreferences = assign({
-      preload: path.join(__dirname, 'renderer-preload')
-    }, options.webPreferences)
-  }
+  opts.webPreferences = assign({
+    preload: path.join(__dirname, 'renderer-preload')
+  }, options.webPreferences)
 
   var window = new BrowserWindow(opts)
   _windows[window.id] = window
@@ -34,7 +28,7 @@ function _unref () {
   delete _windows[this.id]
 }
 
-function _loadUrlWithArgs (httpOrFileUrl, args, callback) {
+function _loadURLWithArgs (httpOrFileUrl, args, callback) {
   if (typeof args === 'function') {
     callback = args
     args = null
@@ -47,28 +41,28 @@ function _loadUrlWithArgs (httpOrFileUrl, args, callback) {
 
   var url = wargs.urlWithArgs(httpOrFileUrl, args)
 
-  // support versions of electron < 0.35.0 before loadUrl was deprecated
-  var loadUrl = win.loadURL ? win.loadURL.bind(win) : win.loadUrl.bind(win)
-  loadUrl(url)
+  win.loadURL(url)
 }
 
 function createWindow (options) {
   var window = _createWindow(options)
   window.unref = _unref.bind(window)
   window.once('close', window.unref)
-  window._loadUrlWithArgs = _loadUrlWithArgs.bind(window)
+  window._loadURLWithArgs = _loadURLWithArgs.bind(window)
 
-  window.showUrl = function (httpOrFileUrl, args, callback) {
+  window.showURL = function (httpOrFileUrl, args, callback) {
     if (typeof args === 'function') {
       callback = args
       args = null
     }
 
-    window._loadUrlWithArgs(httpOrFileUrl, args, function () {
+    window._loadURLWithArgs(httpOrFileUrl, args, function () {
       window.show()
       callback && callback.apply(this, arguments)
     })
   }
+
+  window.showUrl = window.showURL // backwards-compatibility
 
   return window
 }
@@ -77,6 +71,7 @@ module.exports = {
   createWindow: createWindow,
   windows: _windows,
   _createWindow: _createWindow,
-  _loadUrlWithArgs: _loadUrlWithArgs,
+  _loadURLWithArgs: _loadURLWithArgs,
+  _loadUrlWithArgs: _loadURLWithArgs, // backwards-compatibility
   _unref: _unref
 }


### PR DESCRIPTION
This removes the version checks / support for Electron 0.x

Also renames Url -> URL for consistency with Electron (see #8) (still exposing the old names for backwards compatibility)

The tests pass, but this is not tested comprehensively -- happy to make adjustments if I missed something!