### PR TITLE
Add ability to get focused window

### DIFF
--- a/lib/__tests__/main.test.js
+++ b/lib/__tests__/main.test.js
@@ -22,6 +22,20 @@ describe('main', function () {
       assert.strictEqual(main.windows['5'], win)
       assert.strictEqual(win._captureOptions.frame, 'something')
     })
+    it('should expose the getFocusedWindow method of BrowserWindow', function () {
+      function getFocusedWindow () { console.log('arrrr!!') }
+      function BrowserWindow (options) {}
+      BrowserWindow.getFocusedWindow = getFocusedWindow
+      var stubs = {
+        electron: {
+          BrowserWindow: BrowserWindow
+        }
+      }
+      stubs.electron['@noCallThru'] = true
+      var main = proxyquire('../main', stubs)
+
+      assert(main.getFocusedWindow === getFocusedWindow)
+    })
   })
 
   describe('_loadURLWithArgs()', function () {

--- a/lib/main.js
+++ b/lib/main.js
@@ -69,6 +69,7 @@ function createWindow (options) {
 module.exports = {
   createWindow: createWindow,
   windows: _windows,
+  getFocusedWindow: BrowserWindow.getFocusedWindow,
   _createWindow: _createWindow,
   _loadURLWithArgs: _loadURLWithArgs,
   _loadUrlWithArgs: _loadURLWithArgs, // backwards-compatibility


### PR DESCRIPTION
When we create multiple windows, electron's BrowserWindow object has a getFocusedWindow method to allow us to get the focused one. This PR exposes that same functionality here.
