### PR TITLE
Added support for file urls with a file-protocol

### DIFF
--- a/lib/__tests__/args.test.js
+++ b/lib/__tests__/args.test.js
@@ -34,6 +34,13 @@ describe('args', function () {
         url = args.urlWithArgs('/tmp/index.html')
         assert.strictEqual(url, 'file:///tmp/index.html')
       })
+      it('should not change a full file url with protocol', function () {
+        var url = args.urlWithArgs('file:///tmp/index.html', {doThat: 'ok'})
+        assert.strictEqual(url, 'file:///tmp/index.html#%7B%22doThat%22%3A%22ok%22%7D')
+
+        url = args.urlWithArgs('file:///tmp/index.html')
+        assert.strictEqual(url, 'file:///tmp/index.html')
+      })
     })
 
     describe('> when data uri', function () {

--- a/lib/args.js
+++ b/lib/args.js
@@ -14,7 +14,7 @@ function urlWithArgs (urlOrFile, args) {
   args = encode(args)
 
   var u
-  if (urlOrFile.indexOf('http') === 0 || urlOrFile.indexOf('data') === 0) {
+  if (urlOrFile.indexOf('file://') === 0 || urlOrFile.indexOf('http') === 0 || urlOrFile.indexOf('data') === 0) {
     var urlData = url.parse(urlOrFile)
     var hash = urlData.hash || args ? args : undefined
     u = url.format(Object.assign(urlData, { hash: hash }))


### PR DESCRIPTION
Hi,

I ran into an issue where a filepath with a file-protocol was invalid after `args.urlWithArgs` was called. 

Input: `args.urlWithArgs('file:///tmp/index.html', {doThat: 'ok'})`
*Before:* `file:///Users/kloener/github/electron-window/file:/tmp/index.html#%7B%22doThat%22%3A%22ok%22%7D`
*After:* `file:///tmp/index.html#%7B%22doThat%22%3A%22ok%22%7D`

I simply added a check for "file://" in row 17 of `lib/args.js`.

regards,
Christian